### PR TITLE
Build increment version

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -27,7 +27,7 @@ steps:
 - task: Bash@3
   inputs:
     targetType: 'inline'
-    script: 'sed -i ''s/0.0.2/$(Build.BuildNumber).dev1/g'' src/arcus/__init__.py'
+    script: 'sed -i ''s/0.0.2/0.0.2.dev$(BuildID)/g'' src/arcus/__init__.py'
     failOnStderr: true
     
 - script: python -m pip install --upgrade pip setuptools wheel

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -65,6 +65,10 @@ steps:
   inputs:
     pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
 
+- script: |    
+    cat $(PYPIRC_PATH)
+  displayName: 'Build wheels'
+
 - script: |
    python -m twine upload --skip-existing --verbose --repository $(pypi-project-name) --config-file $(PYPIRC_PATH) dist/*.whl
   displayName: 'Publish to PyPi dev'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -24,6 +24,10 @@ steps:
     addToPath: true
     architecture: 'x64'
 
+- task: TwineAuthenticate@1
+  inputs:
+    pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
+
 - task: Bash@3
   inputs:
     targetType: 'inline'
@@ -60,10 +64,6 @@ steps:
 
 - script: python -m pip install --upgrade twine
   displayName: 'Install Twine'
-
-- task: TwineAuthenticate@1
-  inputs:
-    pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
 
 - script: |
    python -m twine upload --skip-existing --verbose --repository $(pypi-project-name) --config-file $(PYPIRC_PATH) dist/*.whl

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -70,7 +70,7 @@ steps:
   displayName: 'Build wheels'
 
 - script: |
-   python -m twine upload --skip-existing --verbose --repository $(pypi-project-name) --config-file $(PYPIRC_PATH) dist/*.whl
+   python -m twine upload --skip-existing --verbose -r $(pypi-endpoint-name) --config-file $(PYPIRC_PATH) dist/*.whl
   displayName: 'Publish to PyPi dev'
 
 - task: CopyFiles@2  

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -44,6 +44,7 @@ stages:
         - script: python -m pip install --upgrade twine
           displayName: 'Install Twine'
   - stage: Build_Test
+    dependsOn: Prereqs
     jobs:
       - job: Set_version_number
         displayName: 'Set dynamic version number'
@@ -56,6 +57,7 @@ stages:
             script: 'sed -i ''s/0.0.2/0.0.2.dev$(Build.BuildNumber)/g'' src/arcus/__init__.py'
             failOnStderr: true
       - job: Run_unit_tests
+        dependsOn: Set_version_number
         displayName: 'Run unit tests'
         pool:
           vmImage: 'ubuntu-latest'
@@ -76,6 +78,7 @@ stages:
             summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
             reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
   - stage: Package_Deploy
+    dependsOn: Build_Test
     jobs:
       - job: Create_package
         displayName: 'Create wheel packages'
@@ -86,6 +89,7 @@ stages:
             python src/setup.py bdist_wheel 
           displayName: 'Build wheels'
       - job: Publish_prerelease_package
+        dependsOn: Create_package
         displayName: 'Create pre release package'
         pool:
           vmImage: 'ubuntu-latest'
@@ -98,6 +102,7 @@ stages:
             python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*.whl
           displayName: 'Publish to PyPi dev'
   - stage: Publish_Artifacts
+    dependsOn: Package_Deploy
     jobs:
       - job: Publish
         displayName: 'Publish build artifacts'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -40,7 +40,7 @@ steps:
     pip install pytest
     pip install pytest-cov
     pytest src/tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
-  displayName: 'Test with pytest'
+  displayName: 'Unit tests (pytest)'
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()
@@ -55,8 +55,8 @@ steps:
     reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
 - script: |    
-    python src/setup.py sdist 
-  displayName: 'Artifact creation'
+    python src/setup.py bdist_wheel 
+  displayName: 'Build wheels'
 
 - script: python -m pip install --upgrade twine
   displayName: 'Install Twine'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -17,8 +17,10 @@ pr:
 
 stages:
   - stage: Prereqs
+    displayName: 'Install pre requisites'
     jobs:
       - job: Install
+        displayName: 'Install all python packages'
         pool:
           vmImage: 'ubuntu-latest'
         steps:
@@ -43,7 +45,8 @@ stages:
           displayName: 'Install Twine'
   - stage: Build_Test
     jobs:
-      - job: Set version number
+      - job: Set_version_number
+        displayName: 'Set dynamic version number'
         pool:
           vmImage: 'ubuntu-latest'
         steps:
@@ -52,7 +55,8 @@ stages:
             targetType: 'inline'
             script: 'sed -i ''s/0.0.2/0.0.2.dev$(Build.BuildNumber)/g'' src/arcus/__init__.py'
             failOnStderr: true
-      - job: Run unit tests
+      - job: Run_unit_tests
+        displayName: 'Run unit tests'
         pool:
           vmImage: 'ubuntu-latest'
         steps:
@@ -73,14 +77,16 @@ stages:
             reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
   - stage: Package_Deploy
     jobs:
-      - job: Create package
+      - job: Create_package
+        displayName: 'Create wheel packages'
         pool:
           vmImage: 'ubuntu-latest'
         steps:
         - script: |    
             python src/setup.py bdist_wheel 
           displayName: 'Build wheels'
-      - job: Publish pre-release package
+      - job: Publish_prerelease_package
+        displayName: 'Create pre release package'
         pool:
           vmImage: 'ubuntu-latest'
         steps:
@@ -93,7 +99,8 @@ stages:
           displayName: 'Publish to PyPi dev'
   - stage: Publish_Artifacts
     jobs:
-      - job: Publish release artifacts
+      - job: Publish
+        displayName: 'Publish build artifacts'
         pool:
           vmImage: 'ubuntu-latest'
         steps:

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -14,101 +14,71 @@ pr:
     - src/*
     - build/ci-build.yml
 
+pool:
+  vmImage: 'ubuntu-latest'
 
-stages:
-  - stage: Build_Test
-    displayName: 'Install pre requisites'
-    jobs:
-      - job: Install
-        displayName: 'Install all python packages'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '3.7'
-            addToPath: true
-            architecture: 'x64'
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.7'
+    addToPath: true
+    architecture: 'x64'
 
-        - script: python -m pip install --upgrade pip setuptools wheel
-          displayName: 'Install tools'
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+    script: 'sed -i ''s/0.0.2/0.0.2.dev$(Build.BuildNumber)/g'' src/arcus/__init__.py'
+    failOnStderr: true
+    
+- script: python -m pip install --upgrade pip setuptools wheel
+  displayName: 'Install tools'
 
-        - script: pip install -r src/requirements.txt
-          displayName: 'Install requirements'
+- script: pip install -r src/requirements.txt
+  displayName: 'Install requirements'
 
-        - script: python -m pip install --upgrade twine
-          displayName: 'Install Twine'
-      - job: Set_version_number
-        dependsOn: Install
-        displayName: 'Set dynamic version number'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-        - task: Bash@3
-          inputs:
-            targetType: 'inline'
-            script: 'sed -i ''s/0.0.2/0.0.2.dev$(Build.BuildNumber)/g'' src/arcus/__init__.py'
-            failOnStderr: true
-      - job: Run_unit_tests
-        dependsOn: Set_version_number
-        displayName: 'Run unit tests'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-        - script: |
-            pip install pytest
-            pip install pytest-cov
-            pytest src/tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
-          displayName: 'Unit tests (pytest)'
+- script: |
+    pip install pytest
+    pip install pytest-cov
+    pytest src/tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+  displayName: 'Unit tests (pytest)'
 
-        - task: PublishTestResults@2
-          condition: succeededOrFailed()
-          inputs:
-            testResultsFiles: '**/test-*.xml'
-            testRunTitle: 'Publish test results for Python $(python.version)'
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFiles: '**/test-*.xml'
+    testRunTitle: 'Publish test results for Python $(python.version)'
 
-        - task: PublishCodeCoverageResults@1
-          inputs:
-            codeCoverageTool: Cobertura
-            summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-            reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
-  - stage: Package_Deploy
-    dependsOn: Build_Test
-    jobs:
-      - job: Create_package
-        displayName: 'Create wheel packages'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-        - script: |    
-            python src/setup.py bdist_wheel 
-          displayName: 'Build wheels'
-      - job: Publish_prerelease_package
-        dependsOn: Create_package
-        displayName: 'Create pre release package'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-        - task: TwineAuthenticate@1
-          inputs:
-            pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+    reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
-        - script: |
-            python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*.whl
-          displayName: 'Publish to PyPi dev'
-  - stage: Publish_Artifacts
-    dependsOn: Package_Deploy
-    jobs:
-      - job: Publish
-        displayName: 'Publish build artifacts'
-        pool:
-          vmImage: 'ubuntu-latest'
-        steps:
-        - task: CopyFiles@2  
-          inputs:    
-            targetFolder: $(Build.ArtifactStagingDirectory)
-        - task: PublishBuildArtifacts@1  
-          inputs:    
-            PathtoPublish: '$(Build.ArtifactStagingDirectory)'                  
-            ArtifactName: 'dist'    
-            publishLocation: 'Container'
+- script: |    
+    python src/setup.py bdist_wheel 
+  displayName: 'Build wheels'
+
+- script: python -m pip install --upgrade twine
+  displayName: 'Install Twine'
+
+- task: TwineAuthenticate@1
+  inputs:
+    pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
+
+- script: |    
+    cat $(PYPIRC_PATH)
+  displayName: 'Print pypirc file'
+
+- script: |
+   python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*.whl
+  displayName: 'Publish to PyPi dev'
+
+- task: CopyFiles@2  
+  inputs:    
+    targetFolder: $(Build.ArtifactStagingDirectory)
+
+- task: PublishBuildArtifacts@1  
+  inputs:    
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'                  
+    ArtifactName: 'dist'    
+    publishLocation: 'Container'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -24,6 +24,12 @@ steps:
     addToPath: true
     architecture: 'x64'
 
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+    script: 'sed -i ''s/0.0.2/0.0.3/g'' src/arcus/__init__.py'
+    failOnStderr: true
+    
 - script: python -m pip install --upgrade pip setuptools wheel
   displayName: 'Install tools'
 
@@ -51,6 +57,17 @@ steps:
 - script: |    
     python src/setup.py sdist 
   displayName: 'Artifact creation'
+
+- script: python -m pip install --upgrade twine
+  displayName: 'Install Twine'
+
+- task: TwineAuthenticate@1
+  inputs:
+    pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
+
+- script: |
+   python -m twine upload --skip-existing --verbose --repository $(pypi-project-name) --config-file $(PYPIRC_PATH) dist/*.whl
+  displayName: 'Publish to PyPi through Twine'
 
 - task: CopyFiles@2  
   inputs:    

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -27,7 +27,7 @@ steps:
 - task: Bash@3
   inputs:
     targetType: 'inline'
-    script: 'sed -i ''s/0.0.2/0.0.3/g'' src/arcus/__init__.py'
+    script: 'sed -i ''s/0.0.2/$(Build.BuildNumber).dev1/g'' src/arcus/__init__.py'
     failOnStderr: true
     
 - script: python -m pip install --upgrade pip setuptools wheel

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -1,4 +1,4 @@
-name: $(date:yyyyMMdd)$(rev:.r)
+name: $(date:yyyyMMdd)$(rev:rr)
 
 trigger:
   branches:

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -16,7 +16,7 @@ pr:
 
 
 stages:
-  - stage: Prereqs
+  - stage: Build_Test
     displayName: 'Install pre requisites'
     jobs:
       - job: Install
@@ -38,10 +38,8 @@ stages:
 
         - script: python -m pip install --upgrade twine
           displayName: 'Install Twine'
-  - stage: Build_Test
-    dependsOn: Prereqs
-    jobs:
       - job: Set_version_number
+        dependsOn: Install
         displayName: 'Set dynamic version number'
         pool:
           vmImage: 'ubuntu-latest'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -14,71 +14,94 @@ pr:
     - src/*
     - build/ci-build.yml
 
-pool:
-  vmImage: 'ubuntu-latest'
 
-steps:
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '3.7'
-    addToPath: true
-    architecture: 'x64'
+stages:
+  - stage: Prereqs
+    jobs:
+      - job: Install
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.7'
+            addToPath: true
+            architecture: 'x64'
 
-- task: Bash@3
-  inputs:
-    targetType: 'inline'
-    script: 'sed -i ''s/0.0.2/0.0.2.dev$(Build.BuildNumber)/g'' src/arcus/__init__.py'
-    failOnStderr: true
-    
-- script: python -m pip install --upgrade pip setuptools wheel
-  displayName: 'Install tools'
+        - script: python -m pip install --upgrade pip setuptools wheel
+          displayName: 'Install tools'
 
-- script: pip install -r src/requirements.txt
-  displayName: 'Install requirements'
+        - script: pip install -r src/requirements.txt
+          displayName: 'Install requirements'
 
-- script: |
-    pip install pytest
-    pip install pytest-cov
-    pytest src/tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
-  displayName: 'Unit tests (pytest)'
+        - script: |
+            pip install pytest
+            pip install pytest-cov
+          displayName: 'Install pytest'
 
-- task: PublishTestResults@2
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFiles: '**/test-*.xml'
-    testRunTitle: 'Publish test results for Python $(python.version)'
+        - script: python -m pip install --upgrade twine
+          displayName: 'Install Twine'
+  - stage: Build_Test
+    jobs:
+      - job: Set version number
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - task: Bash@3
+          inputs:
+            targetType: 'inline'
+            script: 'sed -i ''s/0.0.2/0.0.2.dev$(Build.BuildNumber)/g'' src/arcus/__init__.py'
+            failOnStderr: true
+      - job: Run unit tests
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - script: |
+            pytest src/tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+          displayName: 'Unit tests (pytest)'
 
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+        - task: PublishTestResults@2
+          condition: succeededOrFailed()
+          inputs:
+            testResultsFiles: '**/test-*.xml'
+            testRunTitle: 'Publish test results for Python $(python.version)'
 
-- script: |    
-    python src/setup.py bdist_wheel 
-  displayName: 'Build wheels'
+        - task: PublishCodeCoverageResults@1
+          inputs:
+            codeCoverageTool: Cobertura
+            summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+            reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+  - stage: Package_Deploy
+    jobs:
+      - job: Create package
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - script: |    
+            python src/setup.py bdist_wheel 
+          displayName: 'Build wheels'
+      - job: Publish pre-release package
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - task: TwineAuthenticate@1
+          inputs:
+            pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
 
-- script: python -m pip install --upgrade twine
-  displayName: 'Install Twine'
-
-- task: TwineAuthenticate@1
-  inputs:
-    pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
-
-- script: |    
-    cat $(PYPIRC_PATH)
-  displayName: 'Print pypirc file'
-
-- script: |
-   python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*.whl
-  displayName: 'Publish to PyPi dev'
-
-- task: CopyFiles@2  
-  inputs:    
-    targetFolder: $(Build.ArtifactStagingDirectory)
-
-- task: PublishBuildArtifacts@1  
-  inputs:    
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'                  
-    ArtifactName: 'dist'    
-    publishLocation: 'Container'
+        - script: |
+            python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*.whl
+          displayName: 'Publish to PyPi dev'
+  - stage: Publish_Artifacts
+    jobs:
+      - job: Publish release artifacts
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+        - task: CopyFiles@2  
+          inputs:    
+            targetFolder: $(Build.ArtifactStagingDirectory)
+        - task: PublishBuildArtifacts@1  
+          inputs:    
+            PathtoPublish: '$(Build.ArtifactStagingDirectory)'                  
+            ArtifactName: 'dist'    
+            publishLocation: 'Container'

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -70,7 +70,7 @@ steps:
   displayName: 'Build wheels'
 
 - script: |
-   python -m twine upload --skip-existing --verbose -r '$(pypi-endpoint-name)' --config-file $(PYPIRC_PATH) dist/*.whl
+   python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*.whl
   displayName: 'Publish to PyPi dev'
 
 - task: CopyFiles@2  

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -67,7 +67,7 @@ steps:
 
 - script: |    
     cat $(PYPIRC_PATH)
-  displayName: 'Build wheels'
+  displayName: 'Print pypirc file'
 
 - script: |
    python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*.whl

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -24,10 +24,6 @@ steps:
     addToPath: true
     architecture: 'x64'
 
-- task: TwineAuthenticate@1
-  inputs:
-    pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
-
 - task: Bash@3
   inputs:
     targetType: 'inline'
@@ -65,9 +61,13 @@ steps:
 - script: python -m pip install --upgrade twine
   displayName: 'Install Twine'
 
+- task: TwineAuthenticate@1
+  inputs:
+    pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
+
 - script: |
    python -m twine upload --skip-existing --verbose --repository $(pypi-project-name) --config-file $(PYPIRC_PATH) dist/*.whl
-  displayName: 'Publish to PyPi through Twine'
+  displayName: 'Publish to PyPi dev'
 
 - task: CopyFiles@2  
   inputs:    

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -36,11 +36,6 @@ stages:
         - script: pip install -r src/requirements.txt
           displayName: 'Install requirements'
 
-        - script: |
-            pip install pytest
-            pip install pytest-cov
-          displayName: 'Install pytest'
-
         - script: python -m pip install --upgrade twine
           displayName: 'Install Twine'
   - stage: Build_Test
@@ -63,6 +58,8 @@ stages:
           vmImage: 'ubuntu-latest'
         steps:
         - script: |
+            pip install pytest
+            pip install pytest-cov
             pytest src/tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
           displayName: 'Unit tests (pytest)'
 

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -70,7 +70,7 @@ steps:
   displayName: 'Build wheels'
 
 - script: |
-   python -m twine upload --skip-existing --verbose -r $(pypi-endpoint-name) --config-file $(PYPIRC_PATH) dist/*.whl
+   python -m twine upload --skip-existing --verbose -r '$(pypi-endpoint-name)' --config-file $(PYPIRC_PATH) dist/*.whl
   displayName: 'Publish to PyPi dev'
 
 - task: CopyFiles@2  

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -27,7 +27,7 @@ steps:
 - task: Bash@3
   inputs:
     targetType: 'inline'
-    script: 'sed -i ''s/0.0.2/0.0.2.dev$(BuildID)/g'' src/arcus/__init__.py'
+    script: 'sed -i ''s/0.0.2/0.0.2.dev$(Build.BuildNumber)/g'' src/arcus/__init__.py'
     failOnStderr: true
     
 - script: python -m pip install --upgrade pip setuptools wheel

--- a/src/tests/test_version.py
+++ b/src/tests/test_version.py
@@ -1,14 +1,7 @@
 import sys
 import os
 import pytest
-import arcus.azureml.version as vr
 import arcus 
 
 def test_base():
     assert (2+3) == 5
-
-def test_version_out():
-    assert (vr.output() == '0.0.2')
-
-def test_version_variable():
-    assert (arcus.__version__ == '0.0.2')


### PR DESCRIPTION
- Enabled CI build to publish to pypi.org as pre-release version (taking the version from the code and append the buildid as dev release, which is in form: `yyyyMMddrr`).  A sample version would be : `0.0.2.dev20200418.21`
- Enabled Release build to take the Package.Version parameter as package version that will be included in the release to PyPi.

Closes #23 
Closes #22 
