### PR TITLE
updated Docker base images for Tensorflow & PyTorch GPU/CPU

### DIFF
--- a/arcus/azureml/experimenting/train_environment.py
+++ b/arcus/azureml/experimenting/train_environment.py
@@ -23,11 +23,11 @@ def get_training_environment(ws: Workspace, name: str, pip_file: str, use_gpu: b
     base_environment = environment_type
     if(environment_type == 'tensorflow'):
         # Using Tensorflow Estimator
-        base_environment = 'AzureML-TensorFlow-2.0-GPU' if use_gpu else 'AzureML-TensorFlow-2.0-CPU'
+        base_environment = 'AzureML-TensorFlow-2.3-GPU' if use_gpu else 'AzureML-TensorFlow-2.3-CPU'
     elif(environment_type == 'sklearn'):
         base_environment = 'AzureML-Scikit-learn-0.20.3'
     elif(environment_type == 'pytorch'):
-        base_environment = 'AzureML-PyTorch-1.5-GPU' if use_gpu else 'AzureML-PyTorch-1.5-GPU'
+        base_environment = 'AzureML-PyTorch-1.6-GPU' if use_gpu else 'AzureML-PyTorch-1.6-CPU'
 
     pip_packages=__get_package_list_from_requirements(pip_file)
 


### PR DESCRIPTION
Updating base images for Dockerfile in arcus-azureml, possibly the reason why we can't use GPU for tensorflow when scheduling a train with Arcus is due to incompatible pairs of CUDA & TensorFlow. We should expect this new base image to show compatible pairs of either:

- TF 2.1.0/2.2.0/2.3.0 & Cuda 10.1
- TF 2.4.0 & Cuda 11.0

closes #97 