### PR TITLE
chore: split CI build in re-usable stages

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -94,7 +94,6 @@ stages:
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
   - stage: Release
-    displayName: 'Package and release'
     dependsOn: UnitTests
     condition: succeeded()
     jobs:

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -86,7 +86,7 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFiles: '**/test-*.xml'
-              testRunTitle: 'Publish test results for Python $(python.version)'
+              testRunTitle: 'Publish test results for Python $(Python.Version)'
           - task: PublishCodeCoverageResults@1
             inputs:
               codeCoverageTool: Cobertura
@@ -95,7 +95,7 @@ stages:
 
   - stage: Release
     displayName: 'Package and release'
-    dependsOn: Unit Tests
+    dependsOn: UnitTests
     condition: succeeded()
     jobs:
       - job: PushToPyPi

--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -26,89 +26,100 @@ resources:
       name: arcus-azure/azure-devops-templates
       endpoint: arcus-azure
 
-pool:
-  vmImage: 'ubuntu-latest'
+variables:
+  - template: ./variables/build.yml
 
+pool:
+  vmImage: $(Vm.Image)
 
 stages:
-  - stage: BuildAndTest
-    jobs: 
+  - stage: Build
+    jobs:
       - job: DefineVersion
-        displayName: 'Increase and define version number'
+        displayName: 'Define version number'
         steps:
           - template: 'pypi/determine-pr-version.yml@templates'
             parameters:
               manualTriggerVersion: preview
-
           - task: UsePythonVersion@0
             inputs:
-              versionSpec: '3.7'
+              versionSpec: $(Python.Version)
               addToPath: true
-              architecture: 'x64'
-
           - task: Bash@3
             displayName: 'Update version number'
             inputs:
               targetType: 'inline'
               script: 'sed -i ''s/1.0.0/$(Package.Version).$(Build.BuildNumber)/g'' arcus/azureml/__init__.py'
               failOnStderr: true
+          - task: CopyFiles@2
+            displayName: 'Copy build artifacts'
+            inputs:
+              contents: '**/*.py'
+              targetFolder: '$(Pipeline.Workspace)/build'
+          - task: PublishPipelineArtifact@0
+            displayName: 'Publish build artifacts'
+            inputs:
+              targetPath: '$(Pipeline.Workspace)/build'
+              artifactName: Build
 
+  - stage: UnitTests
+    displayName: Unit Tests
+    dependsOn: Build
+    condition: succeeded()
+    jobs: 
       - job: UnitTests
         displayName: 'Run unit tests'
         steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download build artifacts'
+            inputs:
+              artifact: 'Build'
+              path: '$(Build.SourcesDirectory)'
           - script: pip install -r requirements.txt
             displayName: 'Install requirements.txt'
-
           - script: |
               pip install pytest
               pip install pytest-cov
               pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
             displayName: 'Unit tests (pytest)'
-
           - task: PublishTestResults@2
             condition: succeededOrFailed()
             inputs:
               testResultsFiles: '**/test-*.xml'
               testRunTitle: 'Publish test results for Python $(python.version)'
-
           - task: PublishCodeCoverageResults@1
             inputs:
               codeCoverageTool: Cobertura
               summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
               reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
 
-  - stage: PackageAndRelease
-    displayName: 'Package and release to PyPi'
-    dependsOn: BuildAndTest
+  - stage: Release
+    displayName: 'Package and release'
+    dependsOn: Unit Tests
     condition: succeeded()
     jobs:
-      - job: PackageAndRelease
-        displayName: 'Package and release'
+      - job: PushToPyPi
+        displayName: 'Package wheel and push to PyPi'
         steps:
-          - script: python -m pip install --upgrade pip setuptools wheel lazydocs
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download build artifacts'
+            inputs:
+              artifact: 'Build'
+              path: '$(Build.SourcesDirectory)'
+          - script: python -m pip install --upgrade pip setuptools wheel lazydocs twine
             displayName: 'Install tools'
-
-          - script: python -m pip install --upgrade twine
-            displayName: 'Install Twine'
-            
-          - script: |    
-              python setup.py sdist bdist_wheel 
+          - script: python setup.py sdist bdist_wheel
             displayName: 'Build wheels'
-
           - task: TwineAuthenticate@1
             inputs:
               pythonUploadServiceConnection: 'Arcus AzureML PyPi feed'
-
-          - script: |
-              python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*
+          - script: python -m twine upload --skip-existing --verbose -r 'arcus-azureml' --config-file $(PYPIRC_PATH) dist/*
             displayName: 'Publish to PyPi dev'
-
-          - task: CopyFiles@2  
-            inputs:    
+          - task: CopyFiles@2
+            inputs:
               targetFolder: $(Build.ArtifactStagingDirectory)
-
-          - task: PublishBuildArtifacts@1  
-            inputs:    
-              PathtoPublish: '$(Build.ArtifactStagingDirectory)'                  
-              ArtifactName: 'dist'    
+          - task: PublishBuildArtifacts@1
+            inputs:
+              PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+              ArtifactName: 'dist'
               publishLocation: 'Container'

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,0 +1,3 @@
+variables:
+  Vm.Image: 'ubuntu-latest'
+  Python.Version: '3.7'


### PR DESCRIPTION
Split CI build in separate, re-usable stages.

Continuation of #150 