### PR TITLE
chore: use file paths io url routes

### DIFF
--- a/docs/preview/01-index.md
+++ b/docs/preview/01-index.md
@@ -32,10 +32,10 @@ We offer the following concepts:
 
 We are providing added value in every step of the Machine Learning process.  With every new release, these features will be extended.  Currently we mostly focus on the training and experimentation phase.
 
-- [Interactive experimentations](/features/experimenting) - Evolve your model and experiment with several approaches and parameters, while keeping track of your progress and maintain a reference to every attempt.
-- [Scheduling of trainings](/features/training) - Very commonly, you start locally to train and try a model on a smaller set of data, only to evolve to cloud based training on the full data set. 
-- [Logging metrics of experiments](/features/logging) - A key aspect during training, is the logging of the different metrics and results of your experiment or run.  
-- [Data collection and import](/features/datacollection) - Handy methods to retrieve data and load it into Azure Machine Learning
+- [Interactive experimentations](./02-Features/experimenting.md) - Evolve your model and experiment with several approaches and parameters, while keeping track of your progress and maintain a reference to every attempt.
+- [Scheduling of trainings](./02-Features/training.md) - Very commonly, you start locally to train and try a model on a smaller set of data, only to evolve to cloud based training on the full data set. 
+- [Logging metrics of experiments](/02-Features/logging.md) - A key aspect during training, is the logging of the different metrics and results of your experiment or run.  
+- [Data collection and import](./02-Features/datacollection.md) - Handy methods to retrieve data and load it into Azure Machine Learning
 - Deployment and hosting (future releases)
 - Feedback (future releases)
 

--- a/docs/preview/02-Features/experimenting.md
+++ b/docs/preview/02-Features/experimenting.md
@@ -10,10 +10,10 @@ With `arcus-azureml`, we offer an out of the box library that implements the bes
 With every attempt in an experiment, the following actions can happen without having to write the extra code:
 
 1. Start a new experiment
-1. Launch a new run in the experiment, indicating the specific parameters or description
-1. Evaluate the tested model (classification or regression, for example) and have the results tracked to your run
-1. Persist the actual script/code to the Azure ML backend
-1. Save the trained model to the Azure ML backend
+2. Launch a new run in the experiment, indicating the specific parameters or description
+3. Evaluate the tested model (classification or regression, for example) and have the results tracked to your run
+4. Persist the actual script/code to the Azure ML backend
+5. Save the trained model to the Azure ML backend
 
 ## Common imports
 

--- a/docs/preview/02-Features/training.md
+++ b/docs/preview/02-Features/training.md
@@ -73,7 +73,7 @@ trainer = AzureMLTrainer.CreateFromContext()
 __Data access__
 
 - __File data sets__ will be available in a directory relative to the training folder, with a name that equals the name of the dataset.  (hyphens in the dataset are however not supported).  
-- __Tabular data sets__ can be access through the `AzureMLEnvironment` class, as described in [Interactive experimentations](experimenting)
+- __Tabular data sets__ can be access through the `AzureMLEnvironment` class, as described in [Interactive experimentations](./experimenting.md)
 
 ```python
 df = work_env.load_tabular_dataset('datasetname')
@@ -81,7 +81,7 @@ df = work_env.load_tabular_dataset('datasetname')
 
 __Model evaluation__
 
-It's important to track the evaluation results of the training.  This can be done through the AzureMLTrainer class as described in [Interactive experimentations](experimenting)
+It's important to track the evaluation results of the training.  This can be done through the AzureMLTrainer class as described in [Interactive experimentations](./experimenting.md)
 
 An example to evaluate a classifier.  This will upload the confusion matrix, the RoC curve and the metrics to the Run.
 
@@ -117,12 +117,12 @@ The following steps will take place:
     - `sklearn`: has the scikit-learn packages installed that are providing most common Machine Learning algorithms
     - `pytorch`: has the Deep Learning package of PyTorch installed.
     - `None`: in this case an empty, default Estimator will be taken and all packages have to be provided through the requirements.txt file.
-1. In extra docker layers, there will be other python packages installed, by leveragin the configured requirements.txt file
-1. Once the image is ready, a container instance will be created on the specified compute.
-1. The file data sets will be mounted or downloaded (depending on the configuration) and made available on the docker image (as a relative folder to the training script)
-1. The training script will be launched with the script arguments 
-1. After the script completes, all files that have been written to the logs and the outputs folders will be uploaded to the Run history in AzureML
-1. The container instance will be removed, but the container image will remain in the Azure Container Registry that comes with an AzureML workspace (and is visible in your resource group).  This means that next time, the same image can be reused if the requirements.txt haven't changed.
+2. In extra docker layers, there will be other python packages installed, by leveragin the configured requirements.txt file
+3. Once the image is ready, a container instance will be created on the specified compute.
+4. The file data sets will be mounted or downloaded (depending on the configuration) and made available on the docker image (as a relative folder to the training script)
+5. The training script will be launched with the script arguments 
+6. After the script completes, all files that have been written to the logs and the outputs folders will be uploaded to the Run history in AzureML
+7. The container instance will be removed, but the container image will remain in the Azure Container Registry that comes with an AzureML workspace (and is visible in your resource group).  This means that next time, the same image can be reused if the requirements.txt haven't changed.
 
 __Launching a training on local compute__
 

--- a/docs/versioned_docs/version-v1.1.0/01-index.md
+++ b/docs/versioned_docs/version-v1.1.0/01-index.md
@@ -32,10 +32,10 @@ We offer the following concepts:
 
 We are providing added value in every step of the Machine Learning process.  With every new release, these features will be extended.  Currently we mostly focus on the training and experimentation phase.
 
-- [Interactive experimentations](/features/experimenting) - Evolve your model and experiment with several approaches and parameters, while keeping track of your progress and maintain a reference to every attempt.
-- [Scheduling of trainings](/features/training) - Very commonly, you start locally to train and try a model on a smaller set of data, only to evolve to cloud based training on the full data set. 
-- [Logging metrics of experiments](/features/logging) - A key aspect during training, is the logging of the different metrics and results of your experiment or run.  
-- [Data collection and import](/features/datacollection) - Handy methods to retrieve data and load it into Azure Machine Learning
+- [Interactive experimentations](./02-Features/experimenting.md) - Evolve your model and experiment with several approaches and parameters, while keeping track of your progress and maintain a reference to every attempt.
+- [Scheduling of trainings](./02-Features/training.md) - Very commonly, you start locally to train and try a model on a smaller set of data, only to evolve to cloud based training on the full data set. 
+- [Logging metrics of experiments](./02-Features/logging.md) - A key aspect during training, is the logging of the different metrics and results of your experiment or run.  
+- [Data collection and import](./02-Features/datacollection.md) - Handy methods to retrieve data and load it into Azure Machine Learning
 - Deployment and hosting (future releases)
 - Feedback (future releases)
 

--- a/docs/versioned_docs/version-v1.1.0/02-Features/experimenting.md
+++ b/docs/versioned_docs/version-v1.1.0/02-Features/experimenting.md
@@ -10,10 +10,10 @@ With `arcus-azureml`, we offer an out of the box library that implements the bes
 With every attempt in an experiment, the following actions can happen without having to write the extra code:
 
 1. Start a new experiment
-1. Launch a new run in the experiment, indicating the specific parameters or description
-1. Evaluate the tested model (classification or regression, for example) and have the results tracked to your run
-1. Persist the actual script/code to the Azure ML backend
-1. Save the trained model to the Azure ML backend
+2. Launch a new run in the experiment, indicating the specific parameters or description
+3. Evaluate the tested model (classification or regression, for example) and have the results tracked to your run
+4. Persist the actual script/code to the Azure ML backend
+5. Save the trained model to the Azure ML backend
 
 ## Common imports
 

--- a/docs/versioned_docs/version-v1.1.0/02-Features/training.md
+++ b/docs/versioned_docs/version-v1.1.0/02-Features/training.md
@@ -73,7 +73,7 @@ trainer = AzureMLTrainer.CreateFromContext()
 __Data access__
 
 - __File data sets__ will be available in a directory relative to the training folder, with a name that equals the name of the dataset.  (hyphens in the dataset are however not supported).  
-- __Tabular data sets__ can be access through the `AzureMLEnvironment` class, as described in [Interactive experimentations](experimenting)
+- __Tabular data sets__ can be access through the `AzureMLEnvironment` class, as described in [Interactive experimentations](./experimenting.md)
 
 ```python
 df = work_env.load_tabular_dataset('datasetname')
@@ -81,7 +81,7 @@ df = work_env.load_tabular_dataset('datasetname')
 
 __Model evaluation__
 
-It's important to track the evaluation results of the training.  This can be done through the AzureMLTrainer class as described in [Interactive experimentations](experimenting)
+It's important to track the evaluation results of the training.  This can be done through the AzureMLTrainer class as described in [Interactive experimentations](./experimenting.md)
 
 An example to evaluate a classifier.  This will upload the confusion matrix, the RoC curve and the metrics to the Run.
 
@@ -117,12 +117,12 @@ The following steps will take place:
     - `sklearn`: has the scikit-learn packages installed that are providing most common Machine Learning algorithms
     - `pytorch`: has the Deep Learning package of PyTorch installed.
     - `None`: in this case an empty, default Estimator will be taken and all packages have to be provided through the requirements.txt file.
-1. In extra docker layers, there will be other python packages installed, by leveragin the configured requirements.txt file
-1. Once the image is ready, a container instance will be created on the specified compute.
-1. The file data sets will be mounted or downloaded (depending on the configuration) and made available on the docker image (as a relative folder to the training script)
-1. The training script will be launched with the script arguments 
-1. After the script completes, all files that have been written to the logs and the outputs folders will be uploaded to the Run history in AzureML
-1. The container instance will be removed, but the container image will remain in the Azure Container Registry that comes with an AzureML workspace (and is visible in your resource group).  This means that next time, the same image can be reused if the requirements.txt haven't changed.
+2. In extra docker layers, there will be other python packages installed, by leveragin the configured requirements.txt file
+3. Once the image is ready, a container instance will be created on the specified compute.
+4. The file data sets will be mounted or downloaded (depending on the configuration) and made available on the docker image (as a relative folder to the training script)
+5. The training script will be launched with the script arguments 
+6. After the script completes, all files that have been written to the logs and the outputs folders will be uploaded to the Run history in AzureML
+7. The container instance will be removed, but the container image will remain in the Azure Container Registry that comes with an AzureML workspace (and is visible in your resource group).  This means that next time, the same image can be reused if the requirements.txt haven't changed.
 
 __Launching a training on local compute__
 


### PR DESCRIPTION
Use relative file paths instead of URL routes for linking sub-pages.

Related to https://github.com/arcus-azure/arcus/issues/191﻿
