### PR TITLE
chore: use Arcus team in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # These owners will be the default owners for everything in the repo.
-*       @stijnmoreels @Matthijsdh @PerrineDeBrabant
+*       @arcus-azure/ml-involvement


### PR DESCRIPTION
Use the team io people in the `CODEOWNERS` file.